### PR TITLE
fix : like button

### DIFF
--- a/src/components/BakeryList/BakeryList.tsx
+++ b/src/components/BakeryList/BakeryList.tsx
@@ -29,6 +29,7 @@ export const BakeryList = () => {
       {breads.map((bakery) => (
         <div key={bakery.bakery_id}>
           <BakeryCard
+            bakeryId={bakery.bakery_id}
             image={bakery.image}
             name={bakery.name}
             phone={bakery.phone}

--- a/src/components/commons/BakeryCard.tsx
+++ b/src/components/commons/BakeryCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 type BakeryCard = {
+  bakeryId: string;
   name: string;
   image: string;
   phone: number;
@@ -13,7 +14,13 @@ import LikeButton from "./LikeButton";
 import { useEffect, useState } from "react";
 import { createClient } from "@/supabase/client";
 
-export const BakeryCard = ({ image, name, phone, address }: BakeryCard) => {
+export const BakeryCard = ({
+  bakeryId,
+  image,
+  name,
+  phone,
+  address,
+}: BakeryCard) => {
   return (
     <>
       <div className="flex justify-center items-center">
@@ -30,7 +37,7 @@ export const BakeryCard = ({ image, name, phone, address }: BakeryCard) => {
           <div className="flex justify-between items-center text-lg font-bold text-black mt-2">
             {name}
             <span className="felx left text-red-500 text-xl">
-              <LikeButton />
+              <LikeButton bakeryId={bakeryId} />
             </span>
           </div>
           <div className="border-t border-point my-4"></div>

--- a/src/components/commons/LikeButton.tsx
+++ b/src/components/commons/LikeButton.tsx
@@ -36,6 +36,11 @@ const LikeButton: React.FC<LikeButtonProp> = ({ bakeryId }) => {
   }, []);
 
   const handleToggleLike = async () => {
+    if (userId === null) {
+      alert("로그인 해주세요.");
+      return false;
+    }
+
     try {
       const result = await toggleLikeStatus(isLiked, userId, bakeryId);
       if (result) {

--- a/src/components/commons/LikeButton.tsx
+++ b/src/components/commons/LikeButton.tsx
@@ -9,6 +9,7 @@ import {
 
 const LikeButton: React.FC = () => {
   const [isLiked, setIsLiked] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   // 테스트용 userId, bakeryId
   const userId = "6e2e560b-bd56-4039-806b-6f152ced0853";
@@ -20,6 +21,8 @@ const LikeButton: React.FC = () => {
       setIsLiked(status);
     } catch (error) {
       console.error(error);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -37,6 +40,10 @@ const LikeButton: React.FC = () => {
       console.error(error);
     }
   };
+
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <button onClick={handleToggleLike}>

--- a/src/components/commons/LikeButton.tsx
+++ b/src/components/commons/LikeButton.tsx
@@ -6,14 +6,19 @@ import {
   checkLikeStatus,
   toggleLikeStatus,
 } from "@/app/api/(supabase)/(like)/route";
+import { useUserStore } from "@/store/userStore";
 
-const LikeButton: React.FC = () => {
+interface LikeButtonProp {
+  bakeryId: string;
+}
+
+const LikeButton: React.FC<LikeButtonProp> = ({ bakeryId }) => {
   const [isLiked, setIsLiked] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  // 테스트용 userId, bakeryId
-  const userId = "6e2e560b-bd56-4039-806b-6f152ced0853";
-  const bakeryId = "009a052c-3b40-4500-9416-349b625585b5";
+  const { userId } = useUserStore((state) => ({
+    userId: state.userId,
+  }));
 
   const fetchLikeStatus = async () => {
     try {


### PR DESCRIPTION
- 최초 랜더링 시 좋아요 버튼의 상태를 바로 가져오지 못 하는 문제를 해결했습니다.
- LikeButton 컴포넌트에서 로그인한 유저의 userId와 그 유저가 클릭한 빵집의 bakeryId를 가져오는 부분을 구현했습니다.
- 비로그인 상태에서 좋아요 버튼을 클릭할 경우 로그인을 안내하는 경고문을 표시하도록 구현했습니다.