### PR TITLE
update: Add detail page functionality and refectoring #86

### DIFF
--- a/src/app/(root)/detail/[id]/page.tsx
+++ b/src/app/(root)/detail/[id]/page.tsx
@@ -1,35 +1,79 @@
+import dynamic from "next/dynamic";
+import { Metadata } from "next";
+import { fetchBakeryDetails } from "@/app/api/supabase/(detail)/router";
 import CommentList from "@/components/comment/CommentList";
 import SkeletonMap from "@/components/commons/Skeleton/SkeletonMap";
 import StoreInformation from "@/components/detailMap/StoreInformation";
-import dynamic from "next/dynamic";
-import React from "react";
+import { notFound, redirect } from "next/navigation";
 
-import { notFound } from "../../../../../node_modules/next/navigation";
+// 동적 메타데이터 생성 함수
+export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
+  const { id } = params;
+  const bakery = await fetchBakeryDetails(id);
+
+  if (!bakery) {
+    return {
+      title: "대전 빵집 정보를 찾을 수 없습니다",
+      description: "해당 빵집 정보를 찾을 수 없습니다.",
+      keywords: ["빵집", "Bakery", "베이커리", "디저트", "react", "next.js", "프론트앤드개발자"],
+      authors: [
+        { name: "신자영" },
+        { name: "김민곤" },
+        { name: "천다연" },
+        { name: "김택수" },
+        { name: "윤희수" },
+        { name: "이보아" },
+      ],
+    };
+  }
+
+  return {
+    title: `대빵이 - ${bakery.name}`,
+    description: `${bakery.name} - 대전 빵집의 정보가 담긴 페이지입니다.`,
+    keywords: ["빵집", "Bakery", "베이커리", "디저트", "react", "next.js", "프론트앤드개발자"],
+    authors: [
+      { name: "신자영" },
+      { name: "김민곤" },
+      { name: "천다연" },
+      { name: "김택수" },
+      { name: "윤희수" },
+      { name: "이보아" },
+    ],
+  };
+}
+
 const KakaoMap = dynamic(() => import("@/components/detailMap/KakaoMap"), {
   ssr: false,
   loading: () => <SkeletonMap />,
 });
+
 type DetailPageProps = {
-  searchParams: {
-    name: string;
-    address: string;
-    bakeryId: string;
-    image: string;
-    phone: string;
+  params: {
+    id: string;
   };
 };
-const DetailPage: React.FC<DetailPageProps> = ({ searchParams }) => {
-  const { name, address, bakeryId, image, phone } = searchParams;
 
-  if (!bakeryId) {
+const DetailPage = async ({ params }: DetailPageProps) => {
+  if (!params.id || params.id === "detail") {
+    redirect("/");
+    return null;
+  }
+
+  const bakery = await fetchBakeryDetails(params.id);
+
+  if (!bakery) {
     notFound();
   }
+
+  const { name, address, bakery_id, image, phone } = bakery;
+
   return (
     <div className="reactive-body mx-auto space-y-8">
       {name && address ? <KakaoMap name={name} address={address} /> : <SkeletonMap />}
-      <StoreInformation bakeryId={bakeryId} name={name} address={address} image={image} phone={phone} />
-      <CommentList bakery_id={bakeryId} />
+      <StoreInformation bakeryId={bakery_id} name={name} address={address} image={image} phone={phone} />
+      <CommentList bakery_id={bakery_id} />
     </div>
   );
 };
+
 export default DetailPage;

--- a/src/app/api/supabase/(detail)/router.ts
+++ b/src/app/api/supabase/(detail)/router.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@/supabase/client";
+import { Bakery } from "@/types/bakery";
+
+export const fetchBakeryDetails = async (bakeryId: string): Promise<Bakery | null> => {
+  const supabase = createClient();
+  try {
+    const { data, error } = await supabase.from("bakery").select("*").eq("bakery_id", bakeryId).single();
+    if (error) {
+      console.error("Error fetching bakery details:", error);
+      return null;
+    }
+    return data as Bakery;
+  } catch (error) {
+    console.error("Error fetching bakery details:", error);
+    return null;
+  }
+};

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -3,11 +3,16 @@ import Image from "next/image";
 import Link from "next/link";
 
 const NotFound: React.FC = () => {
+  const headerHeight = 70;
+
   return (
-    <div className="flex items-center justify-center h-screen bg-[#FBF8EE]">
+    <div
+      className="flex flex-col items-center justify-center bg-base overflow-hidden"
+      style={{ minHeight: `calc(100vh - ${headerHeight}px)` }}
+    >
       <div className="text-center">
-        <Image src="/image/404.png" alt="404 이미지" width={400} height={400} className="mx-auto" />
-        <Link href="/" className="text-point hover:underline mt-4 block font-secondary">
+        <Image src="/image/404.png" alt="404 이미지" width={320} height={320} className="mx-auto" />
+        <Link href="/" className="text-point text-subtitle hover:underline mt-4 block font-secondary">
           홈으로 돌아가기
         </Link>
       </div>

--- a/src/components/BakeryList/BakeryList.tsx
+++ b/src/components/BakeryList/BakeryList.tsx
@@ -12,6 +12,7 @@ interface BakeryListProp {
 
 export const BakeryList = ({ searchedBakeries }: BakeryListProp) => {
   const [breads, setBreads] = useState<Bakery[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (searchedBakeries) {
@@ -20,7 +21,10 @@ export const BakeryList = ({ searchedBakeries }: BakeryListProp) => {
       const supabase = createClient();
       const fetchBreads = async () => {
         try {
-          const { data } = await supabase.from("bakery").select("*");
+          const { data, error } = await supabase.from("bakery").select("*");
+          if (error) {
+            throw new Error(error.message);
+          }
           setBreads((data as Bakery[]) || []);
         } catch (error) {
           setError("목록을 불러오는 중 오류가 발생했습니다.");
@@ -34,20 +38,7 @@ export const BakeryList = ({ searchedBakeries }: BakeryListProp) => {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
       {breads.map((bakery) => (
-        <Link
-          href={{
-            pathname: `/detail/${bakery.bakery_id}`,
-            query: {
-              name: bakery.name,
-              address: bakery.address,
-              image: bakery.image,
-              phone: bakery.phone,
-              bakeryId: bakery.bakery_id,
-            },
-          }}
-          key={bakery.bakery_id}
-          passHref
-        >
+        <Link href={`/detail/${bakery.bakery_id}`} key={bakery.bakery_id} passHref>
           <div>
             <BakeryCard
               bakeryId={bakery.bakery_id}

--- a/src/components/comment/CommentList.tsx
+++ b/src/components/comment/CommentList.tsx
@@ -66,7 +66,7 @@ const CommentList: React.FC<CommentProps> = ({ bakery_id: bakeryId }) => {
       <form className="flex items-center gap-2" onSubmit={handleSubmitComment}>
         {/*유저 프로필 */}
         <div className="ml-3">
-          <UserProfile src={profile} />
+          <UserProfile src={profile?.length === 0 ? profile : ""} width={40} height={40} />
         </div>
         {/* <Image src={profile as string} alt="유저 프로필" width={80} height={80} /> */}
         <input

--- a/src/components/detailMap/KakaoMap.tsx
+++ b/src/components/detailMap/KakaoMap.tsx
@@ -1,11 +1,12 @@
 "use client";
 
+import React, { useState, useEffect } from "react";
+import { Map, CustomOverlayMap } from "react-kakao-maps-sdk";
+import Image from "next/image";
+import Link from "next/link";
+import { KakaoMapProps, GeocoderResult, WindowWithKakao } from "@/types/map";
 import { loadKakaoMapScript } from "@/app/api/kakao/route";
 import SkeletonMap from "@/components/commons/Skeleton/SkeletonMap";
-import { GeocoderResult, KakaoMapProps, WindowWithKakao } from "@/types/map";
-import Image from "next/image";
-import React, { useEffect, useState } from "react";
-import { CustomOverlayMap, Map } from "react-kakao-maps-sdk";
 
 const KakaoMap: React.FC<KakaoMapProps> = ({ name, address }) => {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -28,6 +29,7 @@ const KakaoMap: React.FC<KakaoMapProps> = ({ name, address }) => {
       });
   }, [kakaoMapKey, address]);
 
+  // 주소를 좌표로 변환하는 함수
   const searchAddressToCoords = (address: string) => {
     const windowWithKakao = window as WindowWithKakao;
     if (!windowWithKakao.kakao || !windowWithKakao.kakao.maps) return;
@@ -62,10 +64,15 @@ const KakaoMap: React.FC<KakaoMapProps> = ({ name, address }) => {
           yAnchor={1} // 오버레이의 Y 축 앵커 위치
           xAnchor={0.5} // 오버레이의 X 축 앵커 위치
         >
-          <div className="p-0 border-none text-center">
+          <Link
+            href={`https://map.kakao.com/link/map/${name},${coords.lat},${coords.lng}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-0 border-none text-center"
+          >
             <Image src="/image/icons/marker.png" alt={name} width={140} height={140} />
             <p className="m-0 text-[18px] font-bold bg-base p-1 font-secondary">{name}</p>
-          </div>
+          </Link>
         </CustomOverlayMap>
       </Map>
     </div>

--- a/src/components/detailMap/StoreInformation.tsx
+++ b/src/components/detailMap/StoreInformation.tsx
@@ -1,47 +1,40 @@
-
-import Image from 'next/image';
-import LikeButton from '@/components/commons/LikeButton';
-import defaultImg from '../../../public/image/noimg.png';
+import Image from "next/image";
+import LikeButton from "@/components/commons/LikeButton";
+import defaultImg from "../../../public/image/noimg.png";
 
 type StoreInformationProps = {
-    bakeryId: string;
-    name: string | null;
-    address: string | null;
-    image: string | null;
-    phone: string | null;
+  bakeryId: string;
+  name: string | null;
+  address: string | null;
+  image: string | null;
+  phone: string | null;
 };
 
 const StoreInformation: React.FC<StoreInformationProps> = ({ bakeryId, image, name, phone, address }) => {
-    return (
-        <section className="flex flex-col md:flex-row justify-between mt-6">
-            {/* 가게정보_이미지영역 */}
-            <div className="relative w-full md:w-1/3 h-48 md:h-56">
-                <Image
-                    src={image || defaultImg}
-                    alt="베이커리 이미지"
-                    layout="fill"
-                    objectFit="cover"
-                    className="rounded-md"
-                />
-            </div>
-            {/* 가게정보_텍스트영역 */}
-            <div className="w-full md:w-2/3 pt-4 md:pt-0 md:pl-8">
-                <h1 className="mb-3 flex justify-between items-center">
-                    <span className="text-title font-title">{name}</span>
-                    <LikeButton bakeryId={bakeryId} />
-                </h1>
-                <address className="not-italic mb-2">
-                    <dl className="flex items-center space-x-2 mb-3">
-                        <dt>
-                            <Image src="/image/icons/phone.png" alt="전화 아이콘" width={20} height={20} />
-                        </dt>
-                        <dd> {phone ? phone : '매장번호 미제공'}</dd>
-                    </dl>
-                </address>
-                <p>{address}</p>
-            </div>
-        </section>
-    );
+  return (
+    <section className="flex flex-col md:flex-row justify-between mt-6">
+      {/* 가게정보_이미지영역 */}
+      <div className="relative w-full md:w-1/3 h-72 md:h-64">
+        <Image src={image || defaultImg} alt="베이커리 이미지" layout="fill" objectFit="cover" className="rounded-md" />
+      </div>
+      {/* 가게정보_텍스트영역 */}
+      <div className="w-full md:w-2/3 pt-4 md:pt-0 md:pl-8">
+        <h1 className="mb-3 flex justify-between items-center">
+          <span className="text-title font-title">{name}</span>
+          <LikeButton bakeryId={bakeryId} />
+        </h1>
+        <address className="not-italic mb-2">
+          <dl className="flex items-center space-x-2 mb-3">
+            <dt>
+              <Image src="/image/icons/phone.png" alt="전화 아이콘" width={20} height={20} />
+            </dt>
+            <dd> {phone ? phone : "매장번호 미제공"}</dd>
+          </dl>
+        </address>
+        <p>{address}</p>
+      </div>
+    </section>
+  );
 };
 
 export default StoreInformation;

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -5,7 +5,7 @@ import { createClient } from "@/supabase/client";
 import Image from "next/image";
 import Link from "next/link";
 import React from "react";
-import { useRouter } from "../../../node_modules/next/navigation";
+import { useRouter } from "next/navigation";
 import breadImage from "../../../public/image/breads/LogoBread.png";
 import UserProfile from "../commons/UserProfile";
 
@@ -22,16 +22,16 @@ export const Header: React.FC = () => {
   const supabase = createClient();
 
   const handleLogout = async () => {
-    setUser(null, null, null, null);
+    setUser("", "", "", "", "");
     await supabase.auth.signOut();
 
-    router.push("/"); // 로그아웃 후 메인 페이지로 리다이렉트
+    router.push("/");
   };
 
   return (
-    <header className="bg-gray-100 border-b border-gray-300 ">
+    <header className="bg-gray-100 border-b border-gray-300">
       <div className="container mx-auto flex justify-between items-center p-2">
-        <div className="flex px-[200px] ">
+        <div className="flex px-[200px]">
           <Link href={"/"} className="flex">
             <Image src={breadImage} alt="logo" width={50} height={50} />
             <h1 className="text-2xl font-secondary">대빵이</h1>
@@ -63,3 +63,5 @@ export const Header: React.FC = () => {
     </header>
   );
 };
+
+export default Header;


### PR DESCRIPTION
## Description
- 디테일 페이지 지도 클릭시 카카오 페이지로 이동할 수 있도록 링크 추가했습니다. 
- 파라미터 부분 수정 -> api/supbase/(detail)/router.ts 생성 데이터 받아오는거 분리했습니다. 
- 디테일페이지 동적 메타데이터 수정했습니다. 
- 댓글 디폴트 이미지 수정했습니다.
- 404페이지 세로 스크롤 수정했습니다. 



## To-Do
-   [x] 디테일 페이지 파라미터로 데이터 받아오는 부분 수정 
-   [x] 404 페이지 처리 
-   [x] 404 동적 메타데이터 처리
-   [x] 지도 마커에 링크 추가

## up-to-date
2024.07.12